### PR TITLE
feat: Fix when object loses Error instance

### DIFF
--- a/src/object-inspector/ObjectPreview.tsx
+++ b/src/object-inspector/ObjectPreview.tsx
@@ -7,6 +7,7 @@ import { useStyles } from '../styles';
 
 import { hasOwnProperty } from '../utils/objectPrototype';
 import { getPropertyValue } from '../utils/propertyUtils';
+import { isError } from '../utils/isError';
 
 /* intersperse arr with separator */
 function intersperse(arr: any[], sep: string) {
@@ -66,7 +67,7 @@ export const ObjectPreview: FC<any> = ({ data }) => {
       }
     }
 
-    if (object instanceof Error) {
+    if (isError(object)) {
       const errorConstructorName = object.constructor ? object.constructor.name : object.name ? object.name : 'Error';
 
       return (

--- a/src/object/ObjectValue.tsx
+++ b/src/object/ObjectValue.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import { useStyles } from '../styles';
+import { isError } from '../utils/isError';
 
 /**
  * A short description of the object values.
@@ -33,7 +34,7 @@ export const ObjectValue: FC<any> = ({ object, styles }) => {
       if (object instanceof RegExp) {
         return <span style={mkStyle('objectValueRegExp')}>{object.toString()}</span>;
       }
-      if (object instanceof Error) {
+      if (isError(object)) {
         const stackArray = typeof object.stack === 'string' && object.stack.split('\n');
         // Drop the first line if it's the error message (Chrome only)
         const [firstLine, ...stack] = stackArray || [];

--- a/src/tree-view/TreeView.tsx
+++ b/src/tree-view/TreeView.tsx
@@ -5,13 +5,14 @@ import { DEFAULT_ROOT_PATH, hasChildNodes, getExpandedPaths } from './pathUtils'
 
 import { useStyles } from '../styles';
 import { ObjectValue } from '../object/ObjectValue';
+import { isError } from '../utils/isError';
 
 const ConnectedTreeNode = memo<any>((props) => {
   const { data, dataIterator, path, depth, nodeRenderer, onExpand } = props;
   const [expandedPaths, setExpandedPaths] = useContext(ExpandedPathsContext);
   const nodeHasChildNodes = hasChildNodes(data, dataIterator);
   const expanded = !!expandedPaths[path];
-  const isError = data instanceof Error;
+  const dataIsError = isError(data);
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
@@ -46,7 +47,7 @@ const ConnectedTreeNode = memo<any>((props) => {
       {
         // only render if the node is expanded
         expanded ? (
-          isError ? (
+          dataIsError ? (
             <ObjectValue object={data} />
           ) : (
             [...dataIterator(data)].map(({ name, data, ...renderNodeProps }) => {

--- a/src/utils/isError.tsx
+++ b/src/utils/isError.tsx
@@ -1,0 +1,13 @@
+export function isError(obj: object) {
+  if (obj instanceof Error) {
+    return true;
+  }
+
+  // If object has the following properties: `name`, `message`, `stack`, then
+  // assume it is an Error object
+  if ('name' in obj && 'message' in obj && 'stack' in obj) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
If object has the properties: `name`, `message`, and `stack`, treat the object as an Error instance.
